### PR TITLE
fix: update alertmanager configs to route to alert history webhook

### DIFF
--- a/pkg/alert/alertmanager/config.goyaml
+++ b/pkg/alert/alertmanager/config.goyaml
@@ -68,8 +68,11 @@
     group_wait: 30s
     group_interval: 5m
     repeat_interval: 4h
-    receiver: alert_history
-    routes:[[- range $key, $team := .EntityCredentials.Teams]]
+    receiver: default
+    routes:
+      - receiver: alert_history
+        continue: true
+      [[- range $key, $team := .EntityCredentials.Teams]]
       - match:
           team: '[[$team.Name]]'
         routes:

--- a/pkg/alert/alertmanager/configsync_test.go
+++ b/pkg/alert/alertmanager/configsync_test.go
@@ -105,8 +105,10 @@ func TestGenerateAlertmanagerConfig(t *testing.T) {
     group_wait: 30s
     group_interval: 5m
     repeat_interval: 4h
-    receiver: alert_history
+    receiver: default
     routes:
+      - receiver: alert_history
+        continue: true
       - match:
           team: 'eureka'
         routes:


### PR DESCRIPTION
Fixes alert history webhook not being called from Alertmanager